### PR TITLE
Fixed descriptor.proto not found for homebrew installations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export async function generateProtocol(options: UserOptions) {
     const finalOptions = await vaidateOptions(options);
 
     // The places where protocol files can be found
-    const cwdList = [finalOptions.protocolDir, '/usr/local/include', ''];
+    const cwdList = [finalOptions.protocolDir, '/opt/homebrew/include', '/usr/local/include', ''];
 
     if (finalOptions.protoCwd) {
         cwdList.unshift(finalOptions.protoCwd);


### PR DESCRIPTION
Was facing the following error in the homebrew installation of Protobuf. Added homebrew installation directory 

`node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Error: ENOENT: no such file or directory, open 'google/protobuf/descriptor.proto'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'google/protobuf/descriptor.proto'
}
`